### PR TITLE
removing the spinner from the ros2 port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/src/rqt_topic/topic.py
+++ b/src/rqt_topic/topic.py
@@ -41,7 +41,7 @@ class Topic(Plugin):
         super(Topic, self).__init__(context)
         self.setObjectName('Topic')
 
-        self._widget = TopicWidget(context.node, context.spinner, self)
+        self._widget = TopicWidget(context.node, self)
 
         self._widget.start()
         if context.serial_number() > 1:

--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -85,6 +85,10 @@ class TopicInfo(ROSTopicHz):
         self.monitoring = False
         self._reset_data()
         if self._subscriber is not None:
+            qWarning('TopicInfo.stop_monitoring(): '
+                     'Unsubscribing from a topic while the executor is spinning may segfault. '
+                     'This is a known bug in rclpy and is being addressed')
+            qWarning('TopicInfo.stop_monitoring(): See: https://github.com/ros2/rclpy/issues/255')
             self._node.destroy_subscription(self._subscriber)
             self._subscriber = None
 

--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -42,10 +42,9 @@ from ros2topic.verb.hz import ROSTopicHz
 
 class TopicInfo(ROSTopicHz):
 
-    def __init__(self, node, spinner, topic_name, topic_type):
+    def __init__(self, node, topic_name, topic_type):
         super(TopicInfo, self).__init__(node, 100)
         self._node = node
-        self._spinner = spinner
         self._topic_name = topic_name
         self.error = None
         self._subscriber = None
@@ -86,7 +85,7 @@ class TopicInfo(ROSTopicHz):
         self.monitoring = False
         self._reset_data()
         if self._subscriber is not None:
-            self._spinner.register_listeners_for_destruction(self._subscriber)
+            self._node.destroy_subscription(self._subscriber)
             self._subscriber = None
 
     def message_callback(self, message):

--- a/src/rqt_topic/topic_widget.py
+++ b/src/rqt_topic/topic_widget.py
@@ -61,7 +61,7 @@ class TopicWidget(QWidget):
 
     _column_names = ['topic', 'type', 'bandwidth', 'rate', 'value']
 
-    def __init__(self, node, spinner, plugin=None, selected_topics=None,
+    def __init__(self, node, plugin=None, selected_topics=None,
                  select_topic_type=SELECT_BY_NAME, topic_timeout=DEFAULT_TOPIC_TIMEOUT_SECONDS):
         """
         @type selected_topics: list of tuples.
@@ -75,7 +75,6 @@ class TopicWidget(QWidget):
         super(TopicWidget, self).__init__()
 
         self._node = node
-        self._spinner = spinner
         self._logger = self._node.get_logger().get_child('rqt_topic.TopicWidget')
         self._select_topic_type = select_topic_type
         self._topic_timeout = topic_timeout
@@ -179,7 +178,7 @@ class TopicWidget(QWidget):
                         qWarning('rqt_topic: Topic "' + topic_name +
                                  '" has more than one type, choosing the first one of type ' +
                                  topic_types[0])
-                    topic_info = TopicInfo(self._node, self._spinner, topic_name, topic_types[0])
+                    topic_info = TopicInfo(self._node, topic_name, topic_types[0])
                     message_instance = None
                     if topic_info.message_class is not None:
                         message_instance = topic_info.message_class()


### PR DESCRIPTION
Removes the context.spinner from the ros2 port since that is no longer part of the API