### PR TITLE
Give required qos_profile when creating subscription

### DIFF
--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -79,7 +79,8 @@ class TopicInfo(ROSTopicHz):
         if self.message_class is not None:
             self.monitoring = True
             self._subscriber = self._node.create_subscription(
-                self.message_class, self._topic_name, self.message_callback)
+                self.message_class, self._topic_name, self.message_callback,
+                qos_profile=10)
 
     def stop_monitoring(self):
         self.monitoring = False


### PR DESCRIPTION
This should fix an exception when using topic monitor in eloquent. ~~I haven't tried this fix locally.~~  It appears to work locally.

Clicking a check box next to a topic shows an exception about missing the required argument `qos_profile`. This PR adds the parameter with a history depth of 10. 

```
Traceback (most recent call last):
  File "/opt/ros/eloquent/lib/python3.6/site-packages/rqt_topic/topic_widget.py", line 431, in setData
    self._check_state_changed_callback(self._topic_name)
  File "/opt/ros/eloquent/lib/python3.6/site-packages/rqt_topic/topic_widget.py", line 336, in _toggle_monitoring
    self._topics[topic_name]['info'].start_monitoring()
  File "/opt/ros/eloquent/lib/python3.6/site-packages/rqt_topic/topic_info.py", line 82, in start_monitoring
    self.message_class, self._topic_name, self.message_callback)
TypeError: create_subscription() missing 1 required positional argument: 'qos_profile'
Exception ignored in: <bound method DockWidgetTitleBar.__del__ of <qt_gui.dock_widget_title_bar.DockWidgetTitleBar object at 0x7fc4231dfee8>>
```


I tested this locally, and it appears to solve the issue. I think this is unrelated to the PR, but I ran into an issue where my python install would not import `rqt_topic` from an overlay colcon workspace. It looks like the generated `dsv` setup hooks adds to `PYTHONPATH` a path containing a file `rqt-topic.egg-link` which contains a path to the source directory.

```
$ cat install/rqt_topic/lib/python3.6/site-packages/rqt-topic.egg-link 
/home/sloretz/ws/overlay/build/rqt_topic/src
```

As far as I can tell from python documentation, this should be fine, but my python install would not import `rqt_topic` with this setup (`ModuleNotFoundError`). I had to workaround this with 
```
$ export PYTHONPATH=/home/sloretz/ws/overlay/build/rqt_topic/src:$PYTHONPATH
```