### PR TITLE
support order fields as defined in message

### DIFF
--- a/resource/TopicWidget.ui
+++ b/resource/TopicWidget.ui
@@ -56,6 +56,11 @@
        <string>Value</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>MsgOrder</string>
+      </property>
+     </column>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
By default the order of the fields in messages is being used. After sort-by-column is selected the context menu of the header offers an option to reset the order to the default.