### PR TITLE
Fix modern setuptools warning about dashes instead of underscores.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rqt_topic
+script_dir=$base/lib/rqt_topic
 [install]
-install-scripts=$base/lib/rqt_topic
+install_scripts=$base/lib/rqt_topic


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>