### PR TITLE
Making python3 shebangs overt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/rqt_topic/__pycache__/*

--- a/scripts/rqt_topic
+++ b/scripts/rqt_topic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup

--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.

--- a/src/rqt_topic/topic_widget.py
+++ b/src/rqt_topic/topic_widget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2011, Dorian Scholz, TU Darmstadt
 # All rights reserved.


### PR DESCRIPTION
The purpose of this PR is to make the Python executable shebang statements specific to Python3.  

Because noetic is exclusively Python3, being explicit with the shebang simplifies dependencies b/c without installing a package such as python-is-python3, the current shebang causes and error as the system looks for `python` and fails.

For our use-case, we are using docker to isolate the development and CI/CD environments.  Being intentional with the python version makes for more repeatable results and minimizes dependencies.

If there is a cleaner way around this, would appreciate the guidance.