### PR TITLE
Fix python3 install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_topic'],
-    package_dir={'': 'src'}
+    package_dir={'': 'src'},
+    scripts=['scripts/rqt_topic']
 )
 
 setup(**d)


### PR DESCRIPTION
Alternative to #35. This PR is the recommended fix and is backward-compatible with Melodic.

Because `master` branch of this repo is released to both Melodic and Noetic, we need to ensure this is backward compatible for Melodic.

I've tested in both Melodic and Noetic.

@bsb808 could you please test that this works for you and approve the PR?
Once approved, I can merge and release into Noetic. Noetic syncs about once a month, and the [last one](https://discourse.ros.org/t/preparing-for-noetic-sync-2021-11-03/22948) was Nov 4, so the next one should be in a few weeks. Once it syncs, this will be available on `apt-get`.

## To test in Noetic

Compile with installation.
Either with catkin_make (I think this is the command):
```
catkin_make install --pkg rqt_topic
```

Or with catkin-build-tools:
```
catkin config --install
catkin build rqt_topic
```

Source the local workspace
```
. install/setup.bash
```

Verify that rospack is pointing to the local workspace, as opposed to the installed binaries in `/opt/ros`:
```
$ rospack find rqt_topic
/path/to/local_ws/install/share/rqt_topic
```

Check that the installed script in `install/bin/rqt_topic` has `python3` in the shebang:
```
#!/usr/bin/python3
```

Run it:
```
roscore
rosrun rqt_topic rqt_topic
```
GUI should show up.

## To test in Melodic for backward compatibility

Compile and run as above. GUI should show up.
See that the installed script in `install/bin/rqt_topic` has `python2` in the shebang:
```
#!/usr/bin/python2
```