### PR TITLE
Fix removal of topics while they are being monitored.

### DIFF
--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -89,6 +89,9 @@ class TopicInfo(ROSTopicHz):
             self._node.destroy_subscription(self._subscriber)
             self._subscriber = None
 
+    def is_monitoring(self):
+        return self.monitoring
+
     def message_callback(self, message):
         self.last_message = message
         super().callback_hz(message, self._topic_name)


### PR DESCRIPTION
Prior to this change, if a topic was being monitored by rqt_topic
and then went away, it would stay in the window forever.  The main
reason for this is that the subscription that rqt_topic itself
is using counts as one of the topics in the graph, and so it wasn't
"empty" to be deleted.  To fix this, we notice that for every
topic we are currently monitoring, there should be at least one
additional publisher or subscription in the graph besides rqt_topic.
If there is, then we continue monitoring.  If there isn't, we
delete the topic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>