### PR TITLE
Implement bandwidth monitoring.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,8 @@
   <author email="scott@openrobotics.org">Scott K Logan</author>
 
   <exec_depend version_gte="0.2.19">python_qt_binding</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2topic</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
   <exec_depend>rqt_py_common</exec_depend>

--- a/src/rqt_topic/topic_info.py
+++ b/src/rqt_topic/topic_info.py
@@ -30,8 +30,8 @@
 
 from python_qt_binding.QtCore import qWarning
 import rclpy.serialization
-from ros2topic.verb.hz import ROSTopicHz
 from ros2topic.verb.bw import ROSTopicBandwidth
+from ros2topic.verb.hz import ROSTopicHz
 from rqt_py_common.message_helpers import get_message_class
 
 

--- a/src/rqt_topic/topic_widget.py
+++ b/src/rqt_topic/topic_widget.py
@@ -217,9 +217,9 @@ class TopicWidget(QWidget):
                 # If ROSTopicHz.get_hz is called too frequently, it may return None because it does
                 # not have valid statistics
                 rate = None
-                hz_result = topic_info.get_hz(topic_info._topic_name)
+                hz_result = topic_info.get_hz()
                 if hz_result is None:
-                    last_valid_time = topic_info.get_last_printed_tn(topic_info._topic_name)
+                    last_valid_time = topic_info.get_last_printed_tn()
                     current_rostime = topic_info._clock.now().nanoseconds
                     if last_valid_time + self._topic_timeout * 1e9 > current_rostime:
                         # If the last time this was valid was less than the topic timeout param
@@ -231,17 +231,15 @@ class TopicWidget(QWidget):
                 rate_text = '%1.2f' % rate if rate is not None else 'unknown'
 
                 # update bandwidth
-                # TODO (brawner) Currently unsupported
-                bandwidth_text = 'unknown'
-                # bytes_per_s, _, _, _ = topic_info.get_bw()
-                # if bytes_per_s is None:
-                #     bandwidth_text = 'unknown'
-                # elif bytes_per_s < 1000:
-                #     bandwidth_text = '%.2fB/s' % bytes_per_s
-                # elif bytes_per_s < 1000000:
-                #     bandwidth_text = '%.2fKB/s' % (bytes_per_s / 1000.)
-                # else:
-                #     bandwidth_text = '%.2fMB/s' % (bytes_per_s / 1000000.)
+                bytes_per_s, _, _, _, _ = topic_info.get_bw()
+                if bytes_per_s is None:
+                    bandwidth_text = 'unknown'
+                elif bytes_per_s < 1000:
+                    bandwidth_text = '%.2fB/s' % bytes_per_s
+                elif bytes_per_s < 1000000:
+                    bandwidth_text = '%.2fKB/s' % (bytes_per_s / 1000.)
+                else:
+                    bandwidth_text = '%.2fMB/s' % (bytes_per_s / 1000000.)
 
                 # update values
                 value_text = ''
@@ -249,13 +247,10 @@ class TopicWidget(QWidget):
 
             else:
                 rate_text = ''
-                # bytes_per_s = None
                 bandwidth_text = ''
                 value_text = 'not monitored' if topic_info.error is None else topic_info.error
 
             self._tree_items[topic_info._topic_name].setText(self._column_index['rate'], rate_text)
-            # self._tree_items[topic_info._topic_name].setData(
-            #    self._column_index['bandwidth'], Qt.UserRole, bytes_per_s)
             self._tree_items[topic_info._topic_name].setText(
                 self._column_index['bandwidth'], bandwidth_text)
             self._tree_items[topic_info._topic_name].setText(


### PR DESCRIPTION
We now have all of the functionality available to do this,
so finish implementing it.  Note that in order to do this,
I changed the TopicInfo class from a "is-a" ROSTopicHz to
a "has-a" ROSTopicHz, and also added a "has-a" ROSTopicBandwidth.
With all of that in place, it is pretty simple to fetch
the bandwidth data and display it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this requires https://github.com/ros2/ros2cli/pull/708 , so if we want to backport this to Humble we also need to backport that PR.