### PR TITLE
Fix the display of array type elements.

### DIFF
--- a/src/rqt_topic/topic_widget.py
+++ b/src/rqt_topic/topic_widget.py
@@ -28,6 +28,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import array
 import itertools
 import os
 
@@ -284,6 +285,8 @@ class TopicWidget(QWidget):
                 for i in range(len(message), self._tree_items[topic_name].childCount()):
                     item_topic_name = topic_name + '[%d]' % i
                     self._recursive_delete_widget_items(self._tree_items[item_topic_name])
+        elif type(message) == array.array:
+            self._tree_items[topic_name].setText(self._column_index['value'], repr(message.tolist()))
         else:
             if topic_name in self._tree_items:
                 self._tree_items[topic_name].setText(self._column_index['value'], repr(message))


### PR DESCRIPTION
Instead of showing "array('d', [1.0, 2.0])", detect when this
is an array and instead just show the list [1.0, 2.0], which
is much nicer for the user.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #38 