### PR TITLE
Add explicit python3-pytest dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
It is required to run the tests, so make it a test_depend.