### PR TITLE
Tweak expected error in test for Pydantic v2 compat

### DIFF
--- a/test/models/test_message.py
+++ b/test/models/test_message.py
@@ -61,5 +61,5 @@ def test_message_model_incomplete_inputs():
             message_type='test_msgs/BasicTypes',
             timestamp='invalid timestamp',
         )
-    assert 'invalid datetime format' in str(error.value)
+    assert 'validation error for MessageModel\ntimestamp' in str(error.value)
     assert test_msg is None


### PR DESCRIPTION
It appears that the exception text changed when an error like this happens in Pydantic 2.0 and newer. This change asserts part of the message that appears common to both new and old versions of Pydantic.

Both Ubuntu Resolute and RHEL 10 have Pydantic versions greater than 2.0.